### PR TITLE
v3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 #### 소스 데이터
 [https://www.kobis.or.kr/kobisopenapi/homepg/main/main.do]
+*******
 
 #### 테스트 환경
 ```
@@ -62,6 +63,17 @@ export AIRFLOW__CORE__LOAD_EXAMPLES=False
 # 새로운 admin 암호확인
 $ cat ~/airflow_team/standalone_admin_password.txt
 ```
+*****
+#### Extract
+2022년 영화 데이터 월 단위로 추출
+parquet 파일로 저장
 
+#### Transform
+parquet 파일을 DataFrame으로 저장
+중복 데이터 값 merge
+movieCnt(일별 관객수)를 월 단위로 합계하여 매월 인기 영화 집계
+
+#### Load
+tabulate 모듈을 활용하여 산출된 DataFrame을 예쁘게🌸 출력
 
 

--- a/movie_l.py
+++ b/movie_l.py
@@ -1,0 +1,65 @@
+import sys
+from datetime import datetime, timedelta
+from textwrap import dedent
+
+from airflow import DAG
+
+from airflow.operators.bash import BashOperator
+from airflow.operators.empty import EmptyOperator
+
+from airflow.operators.python import (
+    PythonOperator,
+    BranchPythonOperator,
+    PythonVirtualenvOperator,
+
+)
+
+with DAG(
+        'movie_l',
+        default_args={
+            'depends_on_past': False,
+            'retries': 0,
+            'retry_delay': timedelta(seconds=3)
+        },
+        max_active_runs=1,
+        max_active_tasks=3,
+        description='movie',
+        schedule="2 0 1 * *",
+        start_date=datetime(2022, 1, 1),
+        end_date=datetime(2022, 12, 31),
+        catchup=True,
+        tags=['api', 'movie', 'amt'],
+) as dag:
+
+
+    start = BashOperator(
+        task_id="start",
+        bash_command="echo 'start'"
+    )
+
+    def get_tabulate(ds_nodash):
+        from load.api.util import tabulate_df
+
+        before, after = tabulate_df(ds_nodash)
+        print("*"*20)
+        print(before)
+        print("*"*20)
+        print(after)
+        print("*"*20)
+        
+
+    tabulate_L = PythonVirtualenvOperator(
+        task_id="one_to_four",
+        python_callable=get_tabulate,
+        requirements=["git+https://github.com/DE32-Team-Two/Load.git@d3.0.0/tabulate"],
+        system_site_packages=False,
+        
+    )
+    
+    end = BashOperator(
+        task_id="end",
+        bash_command="echo 'end'",
+		trigger_rule='one_success'
+    )
+
+    start >> tabulate_L >> end

--- a/movie_t.py
+++ b/movie_t.py
@@ -1,0 +1,63 @@
+import sys
+from datetime import datetime, timedelta
+from textwrap import dedent
+from pprint import pprint
+
+from airflow import DAG
+
+from airflow.operators.bash import BashOperator
+from airflow.operators.empty import EmptyOperator
+
+from airflow.operators.python import (
+    PythonOperator,
+    BranchPythonOperator,
+    PythonVirtualenvOperator,
+
+)
+
+with DAG(
+        'movie_t',
+        default_args={
+            'depends_on_past': False,
+            'retries': 0,
+            'retry_delay': timedelta(seconds=3)
+        },
+        max_active_runs=1,
+        max_active_tasks=3,
+        description='movie',
+        schedule="0 0 1 * *",
+        start_date=datetime(2022, 1, 1),
+        end_date=datetime(2022, 12, 31),
+        catchup=True,
+        tags=['api', 'movie', 'amt'],
+) as dag:
+
+
+    start = BashOperator(
+        task_id="start",
+        bash_command="echo 'start'"
+    )
+
+    def get_one_echo(ds_nodash):
+        import sys
+        from transform.api.util import merge
+
+        if ds_nodash[4:6] != '01':
+            merge(ds_nodash)
+        
+
+    merge_T = PythonVirtualenvOperator(
+        task_id="one_to_four",
+        python_callable=get_one_echo,
+        requirements=["git+https://github.com/DE32-Team-Two/Transform.git@d3.0.0/merge"],
+        system_site_packages=False,
+        
+    )
+    
+    end = BashOperator(
+        task_id="end",
+        bash_command="echo 'end'",
+		trigger_rule='one_success'
+    )
+
+    start >> merge_T >> end


### PR DESCRIPTION
#### Extract
2022년 영화 데이터 월 단위로 추출
parquet 파일로 저장

#### Transform
parquet 파일을 DataFrame으로 저장
중복 데이터 값 merge
movieCnt(일별 관객수)를 월 단위로 합계하여 매월 인기 영화 집계

#### Load
tabulate 모듈을 활용하여 산출된 DataFrame을 예쁘게🌸 출력